### PR TITLE
Add support for other e2e encryption types

### DIFF
--- a/mod_otr.lua
+++ b/mod_otr.lua
@@ -80,6 +80,11 @@ local function check_message_otr(event)
 		return nil;
 	end
 
+	-- check xep373 pgp (OX) https://xmpp.org/extensions/xep-0373.html
+	if event.stanza:get_child("openpgp", "urn:xmpp:openpgp:0") then
+		return nil;
+	end
+
 	-- no valid encryption found
 
 	-- Warn the user that OTR will not work on MUC but let the message pass.

--- a/mod_otr.lua
+++ b/mod_otr.lua
@@ -26,11 +26,11 @@ local st = require "util.stanza";
 local policy = module:get_option_string("otr_policy", "optional");
 
 local mandatory;
-local mandatory_msg = "For security reasons, OTR encryption is required for conversations on this server";
+local mandatory_msg = "For security reasons, OTR, OMEMO, or PGP encryption is required for conversations on this server";
 local optional;
-local optional_msg = "For security reasons, OTR encryption is STRONGLY recommended for conversations on this server";
+local optional_msg = "For security reasons, OTR, OMEMO, or PGP encryption is STRONGLY recommended for conversations on this server";
 local mixed;
-local muc_msg = "Beware, Multi-User Chat is not supported by OTR."
+local muc_msg = "Beware, Multi-User Chat is not supported by OTR, but is supported by OMEMO or PGP in specific circumstances with some clients."
 
 local messaged = {};
 
@@ -69,6 +69,18 @@ local function check_message_otr(event)
 	if body:sub(1,4) == "?OTR" then
 		return nil;
 	end
+
+	-- check omemo https://xmpp.org/extensions/inbox/omemo.html
+	if event.stanza:get_child("encrypted", "eu.siacs.conversations.axolotl") or event.stanza:get_child("encrypted", "urn:xmpp:omemo:0") then
+		return nil;
+	end
+
+	-- check xep27 pgp https://xmpp.org/extensions/xep-0027.html
+	if event.stanza:get_child("x", "jabber:x:encrypted") then
+		return nil;
+	end
+
+	-- no valid encryption found
 
 	-- Warn the user that OTR will not work on MUC but let the message pass.
 	-- Available for optional and mixed mode.

--- a/mod_otr.lua
+++ b/mod_otr.lua
@@ -23,7 +23,12 @@ local st = require "util.stanza";
 --		mandatory: OTR will be enforced. MUC will not work.
 --		optional:  Warn user to suggest OTR. (default)
 --		mixed: OTR will be enforced in all but MUC.
-local policy = module:get_option_string("otr_policy", "optional");
+local policy = module:get_option_string("e2e_policy", module:get_option_string("otr_policy", "optional"));
+
+local allow_otr = module:get_option_boolean("allow_otr", true);
+local allow_omemo = module:get_option_boolean("allow_omemo", true);
+local allow_xep27_pgp = module:get_option_boolean("allow_xep27_pgp", true);
+local allow_xep373_pgp = module:get_option_boolean("allow_xep373_pgp", true);
 
 local mandatory;
 local mandatory_msg = "For security reasons, OTR, OMEMO, or PGP encryption is required for conversations on this server";
@@ -66,22 +71,22 @@ local function check_message_otr(event)
 	end
 
 	-- If message is OTR, just pass the signal.
-	if body:sub(1,4) == "?OTR" then
+	if allow_otr and body:sub(1,4) == "?OTR" then
 		return nil;
 	end
 
 	-- check omemo https://xmpp.org/extensions/inbox/omemo.html
-	if event.stanza:get_child("encrypted", "eu.siacs.conversations.axolotl") or event.stanza:get_child("encrypted", "urn:xmpp:omemo:0") then
+	if allow_omemo and (event.stanza:get_child("encrypted", "eu.siacs.conversations.axolotl") or event.stanza:get_child("encrypted", "urn:xmpp:omemo:0")) then
 		return nil;
 	end
 
 	-- check xep27 pgp https://xmpp.org/extensions/xep-0027.html
-	if event.stanza:get_child("x", "jabber:x:encrypted") then
+	if allow_xep27_pgp and event.stanza:get_child("x", "jabber:x:encrypted") then
 		return nil;
 	end
 
 	-- check xep373 pgp (OX) https://xmpp.org/extensions/xep-0373.html
-	if event.stanza:get_child("openpgp", "urn:xmpp:openpgp:0") then
+	if allow_xep373_pgp and event.stanza:get_child("openpgp", "urn:xmpp:openpgp:0") then
 		return nil;
 	end
 


### PR DESCRIPTION
This adds support for OMEMO, XEP-27 PGP, and XEP-373 OX PGP.  I made each configurable so you could set up a server that only allowed OMEMO for instance.

Arguably you'd rename this to mod_e2e or something, but I didn't go that far. :)
